### PR TITLE
Remove setuptools from PEP 517 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ codecov = "2.1.12"
 twine = "*"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.coverage.report]


### PR DESCRIPTION
I see it was added in https://github.com/vemel/newversion/commit/09377c310cb5dadcc7af7b7971588ef145761aed, but I don't understand why. A PEP 517 build using poetry-core shouldn't need setuptools.